### PR TITLE
Use `std::runtime_error` rather than `std::exception`

### DIFF
--- a/MissionScanner.cpp
+++ b/MissionScanner.cpp
@@ -53,7 +53,7 @@ std::vector<std::string> FindMissionPaths(int argc, char** argv)
 		}
 		else
 		{
-			throw std::exception("The following path was provided, but does not appear as a valid file path or directory.");
+			throw std::runtime_error("The following path was provided, but does not appear as a valid file path or directory.");
 		}
 	}
 


### PR DESCRIPTION
A Microsoft specific extension allows the `std::exception` construction to take an exception message. For standard C++, consider instead using the derived class `std::runtime_error`, which is guaranteed to allow an exception message to be passed to the constructor.
