### PR TITLE
Column adjustments

### DIFF
--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <cstddef>
 #include <array>
+#include <algorithm>
 
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
@@ -56,6 +57,7 @@ void WriteTable(std::vector<std::string> missionPaths)
 {
 	WriteHeader();
 
+	std::sort(missionPaths.begin(), missionPaths.end());
 	for (const auto& missionPath : missionPaths)
 	{
 		try {

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -40,15 +40,15 @@ constexpr std::array<std::streamsize, 7> columnWidths{ 9, 48, 22, 24, 18, 2, 5 }
 
 constexpr std::array<std::string_view, 8> missionTypes{
 	// Single player
-	"Colony Game",
-	"Demo",
-	"Tutorial",
+	"Col",
+	"Dem",
+	"Tut",
 	// Multiplayer
-	"Land Rush",
-	"Space Race",
-	"Resource Race",
-	"Midas",
-	"Last One Standing",
+	"MLR",
+	"MSP",
+	"MRR",
+	"MM",
+	"ML",
 };
 
 
@@ -138,7 +138,7 @@ std::string_view ConvertMissionTypeToString(MissionTypes missionType)
 {
 	// Positive missionTypes represent campaign mission index.
 	if (static_cast<int>(missionType) > 0) {
-		return "Campaign";
+		return "Cam";
 	}
 	// Negative values represent non-campaign game types (range -1..-8)
 	auto missionTypeIndex = static_cast<std::size_t>(-missionType) - 1;

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -32,11 +32,11 @@ constexpr std::array<std::string_view, 7> columnTitles{
 	"MISSION DESCRIPTION",
 	"MAP NAME",
 	"TECH TREE NAME",
-	"MISSION TYPE",
+	"TYP",
 	"#",
-	"UNIT",
+	"U",
 };
-constexpr std::array<std::streamsize, 7> columnWidths{ 9, 48, 22, 24, 18, 2, 5 };
+constexpr std::array<std::streamsize, 7> columnWidths{ 9, 48, 22, 24, 4, 2, 2 };
 
 constexpr std::array<std::string_view, 8> missionTypes{
 	// Single player

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -124,9 +124,9 @@ void WriteCell(MissionTypes missionType, std::streamsize cellWidthInChars)
 
 void WriteBoolCell(bool boolean, std::streamsize cellWidthInChars)
 {
-	std::string booleanString("True");
+	std::string booleanString("T");
 	if (!boolean) {
-		booleanString = "False";
+		booleanString = "F";
 	}
 
 	WriteCell(booleanString, cellWidthInChars);

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -28,15 +28,15 @@ void WriteBoolCell(bool boolean, std::streamsize cellWidthInChars);
 std::string_view ConvertMissionTypeToString(MissionTypes missionType);
 
 constexpr std::array<std::string_view, 7> columnTitles{
-	"#",
-	"TYP",
-	"U",
 	"DLL NAME",
+	"TYP",
+	"#",
+	"U",
 	"MAP NAME",
 	"TECH TREE NAME",
 	"MISSION DESCRIPTION",
 };
-constexpr std::array<std::streamsize, 7> columnWidths{ 2, 4, 2, 9, 18, 24, 1 };
+constexpr std::array<std::streamsize, 7> columnWidths{ 9, 4, 2, 2, 18, 24, 1 };
 
 constexpr std::array<std::string_view, 8> missionTypes{
 	// Single player
@@ -85,12 +85,12 @@ void WriteRow(DllExportedVariableReader32& dllReader, std::string_view filename)
 {
 	try 
 	{
-		auto aiModDesc = dllReader.ReadExport<AIModDesc>("DescBlock");
-		WriteCell(aiModDesc.numPlayers, columnWidths[0]);
-		WriteCell(static_cast<MissionTypes>(aiModDesc.missionType), columnWidths[1]);
-		WriteBoolCell(static_cast<bool>(aiModDesc.boolUnitMission), columnWidths[2]);
+		WriteCell(filename, columnWidths[0]);
 
-		WriteCell(filename, columnWidths[3]);
+		auto aiModDesc = dllReader.ReadExport<AIModDesc>("DescBlock");
+		WriteCell(static_cast<MissionTypes>(aiModDesc.missionType), columnWidths[1]);
+		WriteCell(aiModDesc.numPlayers, columnWidths[2]);
+		WriteBoolCell(static_cast<bool>(aiModDesc.boolUnitMission), columnWidths[3]);
 
 		// Some missions do not store LevelDesc, MapName, and TechTreeName within AIModDesc
 		WriteCell(dllReader.ReadExportString("MapName"), columnWidths[4]);

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -28,15 +28,15 @@ void WriteBoolCell(bool boolean, std::streamsize cellWidthInChars);
 std::string_view ConvertMissionTypeToString(MissionTypes missionType);
 
 constexpr std::array<std::string_view, 7> columnTitles{
+	"#",
+	"TYP",
+	"U",
 	"DLL NAME",
-	"MISSION DESCRIPTION",
 	"MAP NAME",
 	"TECH TREE NAME",
-	"TYP",
-	"#",
-	"U",
+	"MISSION DESCRIPTION",
 };
-constexpr std::array<std::streamsize, 7> columnWidths{ 9, 48, 22, 24, 4, 2, 2 };
+constexpr std::array<std::streamsize, 7> columnWidths{ 2, 4, 2, 9, 22, 24, 48 };
 
 constexpr std::array<std::string_view, 8> missionTypes{
 	// Single player
@@ -85,17 +85,17 @@ void WriteRow(DllExportedVariableReader32& dllReader, std::string_view filename)
 {
 	try 
 	{
-		WriteCell(filename, columnWidths[0]);
+		auto aiModDesc = dllReader.ReadExport<AIModDesc>("DescBlock");
+		WriteCell(aiModDesc.numPlayers, columnWidths[0]);
+		WriteCell(static_cast<MissionTypes>(aiModDesc.missionType), columnWidths[1]);
+		WriteBoolCell(static_cast<bool>(aiModDesc.boolUnitMission), columnWidths[2]);
 
-		WriteCell(dllReader.ReadExportString("LevelDesc"), columnWidths[1]);
-		WriteCell(dllReader.ReadExportString("MapName"), columnWidths[2]);
-		WriteCell(dllReader.ReadExportString("TechtreeName"), columnWidths[3]);
+		WriteCell(filename, columnWidths[3]);
 
 		// Some missions do not store LevelDesc, MapName, and TechTreeName within AIModDesc
-		auto aiModDesc = dllReader.ReadExport<AIModDesc>("DescBlock");
-		WriteCell(static_cast<MissionTypes>(aiModDesc.missionType), columnWidths[4]);
-		WriteCell(aiModDesc.numPlayers, columnWidths[5]);
-		WriteBoolCell(static_cast<bool>(aiModDesc.boolUnitMission), columnWidths[6]);
+		WriteCell(dllReader.ReadExportString("MapName"), columnWidths[4]);
+		WriteCell(dllReader.ReadExportString("TechtreeName"), columnWidths[5]);
+		WriteCell(dllReader.ReadExportString("LevelDesc"), columnWidths[6]);
 	}
 	catch (const std::exception& e) 
 	{

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -36,7 +36,7 @@ constexpr std::array<std::string_view, 7> columnTitles{
 	"TECH TREE NAME",
 	"MISSION DESCRIPTION",
 };
-constexpr std::array<std::streamsize, 7> columnWidths{ 2, 4, 2, 9, 22, 24, 48 };
+constexpr std::array<std::streamsize, 7> columnWidths{ 2, 4, 2, 9, 18, 24, 1 };
 
 constexpr std::array<std::string_view, 8> missionTypes{
 	// Single player


### PR DESCRIPTION
This builds on top of PR #17. ~~Review may be easier if the base branch is merged first and this branch rebased on top of it.~~ Edit: Rebase completed.

This work supports issue #6. This PR re-orders and re-sizes columns. This produces better display for narrower standard 80 column wide terminal windows.

Testing with a recent game install shows only 2 entries overflow the 80 column wide width. This is done in a way that is quite legible.

Not addressed is output of a legend for the abbreviated entries.
