### PR TITLE
Enable x64 compilation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ configuration:
   - Release
 platform:
   - x86
+  - x64
 install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - git submodule update --init --recursive

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "OP2Utility"]
 	path = OP2Utility
 	url = https://github.com/OutpostUniverse/OP2Utility.git
-[submodule "Outpost2DLL"]
-	path = Outpost2DLL
-	url = https://github.com/OutpostUniverse/Outpost2DLL.git

--- a/MissionScanner.sln
+++ b/MissionScanner.sln
@@ -7,8 +7,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MissionScanner", "MissionSc
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Utility", "OP2Utility\OP2Utility.vcxproj", "{980D53D9-F9E2-4682-9307-1303C9E42313}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "Outpost2DLL\Outpost2DLL.vcxproj", "{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -23,10 +21,6 @@ Global
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x86.Build.0 = Debug|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x86.ActiveCfg = Release|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x86.Build.0 = Release|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.ActiveCfg = Debug|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.Build.0 = Debug|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.ActiveCfg = Release|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MissionScanner.sln
+++ b/MissionScanner.sln
@@ -9,16 +9,26 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OP2Utility", "OP2Utility\OP
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Debug|x64.ActiveCfg = Debug|x64
+		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Debug|x64.Build.0 = Debug|x64
 		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Debug|x86.ActiveCfg = Debug|Win32
 		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Debug|x86.Build.0 = Debug|Win32
+		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Release|x64.ActiveCfg = Release|x64
+		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Release|x64.Build.0 = Release|x64
 		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Release|x86.ActiveCfg = Release|Win32
 		{AC1CA411-8E09-4F40-A672-6A2D98AB3ECB}.Release|x86.Build.0 = Release|Win32
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.ActiveCfg = Debug|x64
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.Build.0 = Debug|x64
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x86.ActiveCfg = Debug|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x86.Build.0 = Debug|Win32
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x64.ActiveCfg = Release|x64
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x64.Build.0 = Release|x64
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x86.ActiveCfg = Release|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/MissionScanner.vcxproj
+++ b/MissionScanner.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DllExportReader32.cpp" />
@@ -52,6 +60,19 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -63,11 +84,23 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -76,6 +109,22 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
@@ -98,6 +147,25 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/MissionScanner.vcxproj
+++ b/MissionScanner.vcxproj
@@ -19,15 +19,13 @@
     <ClInclude Include="DllExportReader32.h" />
     <ClInclude Include="LocalResource.h" />
     <ClInclude Include="MissionTable.h" />
+    <ClInclude Include="Outpost2DllExportedDefinitions.h" />
     <ClInclude Include="PEDataStructures.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="OP2Utility\OP2Utility.vcxproj">
       <Project>{980d53d9-f9e2-4682-9307-1303c9e42313}</Project>
-    </ProjectReference>
-    <ProjectReference Include="Outpost2DLL\Outpost2DLL.vcxproj">
-      <Project>{b3f40368-f3cc-4ec5-a758-f5dad08feddc}</Project>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -80,7 +78,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>OP2Utility/include; Outpost2DLL</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -98,7 +96,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>OP2Utility/include; Outpost2DLL</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>OP2Utility/include;</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/MissionScanner.vcxproj.filters
+++ b/MissionScanner.vcxproj.filters
@@ -17,6 +17,7 @@
     <ClInclude Include="MissionTable.h" />
     <ClInclude Include="PEDataStructures.h" />
     <ClInclude Include="DllExportReader32.h" />
+    <ClInclude Include="Outpost2DllExportedDefinitions.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="MissionScanner.rc">

--- a/MissionTable.cpp
+++ b/MissionTable.cpp
@@ -1,6 +1,6 @@
 #include "MissionTable.h"
 #include "DllExportReader32.h"
-#include "Outpost2DLL.h"
+#include "Outpost2DllExportedDefinitions.h"
 #include <iomanip>
 #include <iostream>
 #include <string_view>

--- a/Outpost2DllExportedDefinitions.h
+++ b/Outpost2DllExportedDefinitions.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Pulled from Outpost2DLL project to remove formal compilation reference to the entire Outpost2DLL project
+
+
+// Structure for important data exports needed for OP2 to recognize the level
+struct AIModDesc
+{
+	// Important level details
+	int missionType;			// Mission type (defined above) or mission number (positive values) for campaign games
+	int numPlayers;				// Number of players (on a multipalyer map)
+	int maxTechLevel;			// Maximum tech level (Set to 12 to enable all techs)
+	int boolUnitMission;		// Set to 1 to disable most reports (suitable for unit-only missions)
+	// Extra baggage that doesn't need to be set properly
+	const char* mapName;
+	const char* levelDesc;
+	const char* techtreeName;
+	int checksum;
+};
+
+
+// Mission types, and the corresponding DLL name prefix
+// Note: For campaign games, use a positive level number, and a prefix of e (Eden) or p (Plymouth)
+// Note: Multiplayer games include the max number of players (denoted by <x>).
+//   Example: ml6_99.dll  (Multiplayer, Last One Standing, Max of 6 players)
+enum MissionTypes
+{
+	Colony = -1, //0xFF	// c
+	AutoDemo = -2, //0xFF	// a
+	Tutorial = -3, //0xFD	// t
+
+	MultiLandRush = -4, //0xFC	// mu<x>
+	MultiSpaceRace = -5, //0xFB	// mf<x>
+	MultiResourceRace = -6, //0xFA	// mr<x>
+	MultiMidas = -7, //0xF9	// mm<x>
+	MultiLastOneStanding = -8, //0xF8	// ml<x>
+};


### PR DESCRIPTION
I wanted to see if the DllExportReader worked when compiled in x64. I had to remove the Outpost2DLL project since it only works in x86. This required bringing in a structure and enum definition from Outpost2DLL. 

Good news it does work!

@DanRStevens what do you think about this change? Is it worth removing Outpost2DLL to allow for x64 compilation?