### PR TITLE
Remove makefile dependence on Outpost2DLL project

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ include makefile-generic.mk
 config := clang
 
 
-CPPFLAGS := -IOP2Utility/include/ -IOutpost2DLL/ -DOP2="" -D__fastcall="" -D__cdecl=""
+CPPFLAGS := -IOP2Utility/include/
 CXXFLAGS := -std=c++17 -O2 -g -Wall -Wno-unknown-pragmas
 LDFLAGS := -LOP2Utility/
 LDLIBS := -lOP2Utility -lstdc++fs


### PR DESCRIPTION
This also gets rid of the weird preprocessor defines that were needed to process the Outpost2DLL code.

Edit: Just realized this is a Linux only change.
