### PR TITLE
Fix Linux build errors

### DIFF
--- a/DllExportReader32.h
+++ b/DllExportReader32.h
@@ -31,7 +31,7 @@ public:
 	bool DoesExportExist(const std::string& exportName);
 
 private:
-	Stream::FileReader stream;
+	OP2Utility::Stream::FileReader stream;
 
 	std::vector<SectionTable> sectionTables;
 	std::vector<std::string> exportNameTable;

--- a/MissionScanner.cpp
+++ b/MissionScanner.cpp
@@ -82,16 +82,16 @@ std::vector<std::string> FindMissionPaths(const std::vector<std::string>& argume
 
 	for (const auto& argument : arguments)
 	{
-		if (XFile::IsDirectory(argument)) {
-			std::vector<std::string> directoryFilenames = XFile::DirFilesWithExtension(argument, ".dll");
+		if (OP2Utility::XFile::IsDirectory(argument)) {
+			std::vector<std::string> directoryFilenames = OP2Utility::XFile::DirFilesWithExtension(argument, ".dll");
 
 			for (auto& filename : directoryFilenames) {
-				filename = XFile::Append(argument, filename);
+				filename = OP2Utility::XFile::Append(argument, filename);
 			}
 
 			missionPaths.insert(missionPaths.end(), directoryFilenames.begin(), directoryFilenames.end());
 		}
-		else if (XFile::IsFile(argument)) {
+		else if (OP2Utility::XFile::IsFile(argument)) {
 			missionPaths.push_back(argument);
 		}
 		else


### PR DESCRIPTION
Fixes Linux build errors seen with recent versions of GCC and Clang.

Older compilers did not detect these minor defects.

Related:
- PR https://github.com/OutpostUniverse/OP2Utility/pull/401
