### PR TITLE
Update AppVeyor for default branch rename to `main`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ artifacts:
     name: BuildArtifacts
 deploy:
   on:
-    branch: master
+    branch: main
     APPVEYOR_REPO_TAG: true
     CONFIGURATION: Release
   artifact: BuildArtifacts


### PR DESCRIPTION
Related:
- Issue https://github.com/OutpostUniverse/OP2Utility/issues/414
