### PR TITLE
Update CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 jobs:
   gcc:
     docker:
-      - image: outpostuniverse/op2utility:1.2
+      - image: outpostuniverse/op2utility:1.5
     steps:
       - checkout
       - run: git submodule update --init || true
       - run: make --keep-going --jobs=2 config=gcc
   clang:
     docker:
-      - image: outpostuniverse/op2utility:1.2
+      - image: outpostuniverse/op2utility:1.5
     steps:
       - checkout
       - run: git submodule update --init || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   gcc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       - run: make --keep-going --jobs=2 config=clang
 
 workflows:
-  version: 2
   build:
     jobs:
       - gcc


### PR DESCRIPTION
Update CircleCI workflow to version `2.1` to resolve deprecation warning, and updated Docker images used to latest.

----

The workflow in OP2Utility that builds the Docker images only pushes them to a GitHub Docker registry, not to DockerHub. To make the latest build image available on DockerHub it was transferred manually using:
```sh
docker image pull ghcr.io/outpostuniverse/op2utility:1.5
docker tag ghcr.io/outpostuniverse/op2utility:1.5 outpostuniverse/op2utility:1.5
docker image push outpostuniverse/op2utility:1.5
```

----

Related:
- Issue https://github.com/OutpostUniverse/OP2Utility/issues/414
- PR https://github.com/OutpostUniverse/OP2Utility/pull/459
